### PR TITLE
Missing import

### DIFF
--- a/quickstep/src/com/android/quickstep/views/MemInfoView.java
+++ b/quickstep/src/com/android/quickstep/views/MemInfoView.java
@@ -18,7 +18,7 @@
 
 package com.android.quickstep.views;
 
-
+import android.os.HandlerThread;
 import android.app.ActivityManager;
 import android.content.Context;
 import android.content.Intent;


### PR DESCRIPTION
packages/apps/Launcher3/quickstep/src/com/android/quickstep/views/MemInfoView.java:99:  error: could not resolve HandlerThread
private static final HandlerThread BACKGROUND_THREAD = new HandlerThread("MemoryInfoThread");